### PR TITLE
Add adjustable corner radius for dynamic blur

### DIFF
--- a/resources/ui/applications.ui
+++ b/resources/ui/applications.ui
@@ -60,6 +60,27 @@ To get the best results possible, although with reduced performances, you can ch
 
         <child>
           <object class="AdwActionRow">
+            <property name="title" translatable="yes">Corner radius</property>
+            <property name="subtitle" translatable="yes">Radius for the rounded corners.</property>
+            <property name="activatable-widget">corner_radius_scale</property>
+            <property name="sensitive" bind-source="blur" bind-property="state" bind-flags="sync-create" />
+
+            <child>
+              <object class="GtkScale" id="corner_radius_scale">
+                <property name="valign">center</property>
+                <property name="hexpand">true</property>
+                <property name="width-request">200px</property>
+                <property name="draw-value">true</property>
+                <property name="value-pos">right</property>
+                <property name="digits">0</property>
+                <property name="adjustment">corner_radius</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="AdwActionRow">
             <property name="title" translatable="yes">Opacity</property>
             <property name="subtitle" translatable="yes">The opacity of the window on top of the blur effect, a higher value will be more legible.</property>
             <property name="activatable-widget">opacity_scale</property>
@@ -213,6 +234,12 @@ This may cause some latency or performance issues.</property>
     <property name="lower">0.0</property>
     <property name="upper">1.0</property>
     <property name="step-increment">0.01</property>
+  </object>
+
+  <object class="GtkAdjustment" id="corner_radius">
+    <property name="lower">0</property>
+    <property name="upper">50</property>
+    <property name="step-increment">1</property>
   </object>
 
   <object class="GtkAdjustment" id="opacity">

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -366,6 +366,11 @@
             <default>1.</default>
             <summary>Brightness to use for the blur effect</summary>
         </key>
+        <!-- CORNER RADIUS -->
+        <key type="i" name="corner-radius">
+            <default>12</default>
+            <summary>Radius for the corner rounding effect</summary>
+        </key>
         <!-- COLOR -->
         <key type="(dddd)" name="color">
             <default>(0.,0.,0.,0.)</default>

--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -150,6 +150,10 @@ export const ApplicationsBlur = class ApplicationsBlur {
             meta_window, 'size-changed',
             _ => this.update_size(pid)
         );
+        this.connections.connect(
+            meta_window, 'position-changed',
+            _ => this.update_size(pid)
+        );
 
         // remove the blur when the window is unmanaged
         this.connections.connect(
@@ -306,11 +310,14 @@ export const ApplicationsBlur = class ApplicationsBlur {
                 blur_actor.hide();
                 this.set_window_opacity(window_actor, 255);
             }
+            if (meta_window)
+                this.update_size(meta_window.bms_pid);
         }
         // if we remove the focus and have blur, show it and make the window transparent
         else if (blur_actor) {
             blur_actor.show();
             this.set_window_opacity(window_actor, this.settings.applications.OPACITY);
+            this.update_size(meta_window.bms_pid);
         }
     }
 

--- a/src/conveniences/dummy_pipeline.js
+++ b/src/conveniences/dummy_pipeline.js
@@ -45,7 +45,9 @@ export const DummyPipeline = class DummyPipeline {
             unscaled_radius: 2 * this.settings.SIGMA,
             brightness: this.settings.BRIGHTNESS,
         });
-        this.corner_effect = this.effects_manager.new_corner_effect({ radius: 12 });
+        this.corner_effect = this.effects_manager.new_corner_effect({
+            radius: this.settings.CORNER_RADIUS ?? 12
+        });
 
         this.actor_destroy_id = this.actor.connect(
             "destroy", () => this.remove_pipeline_from_actor()
@@ -79,6 +81,12 @@ export const DummyPipeline = class DummyPipeline {
         this._brightness_changed_id = this.settings.settings.connect(
             'changed::brightness', () => this.effect.brightness = this.settings.BRIGHTNESS
         );
+        if ('CORNER_RADIUS' in this.settings) {
+            this._corner_radius_changed_id = this.settings.settings.connect(
+                'changed::corner-radius',
+                () => this.corner_effect.radius = this.settings.CORNER_RADIUS
+            );
+        }
     }
 
     repaint_effect() {
@@ -99,8 +107,11 @@ export const DummyPipeline = class DummyPipeline {
             this.settings.settings.disconnect(this._sigma_changed_id);
         if (this._brightness_changed_id)
             this.settings.settings.disconnect(this._brightness_changed_id);
+        if (this._corner_radius_changed_id)
+            this.settings.settings.disconnect(this._corner_radius_changed_id);
         delete this._sigma_changed_id;
         delete this._brightness_changed_id;
+        delete this._corner_radius_changed_id;
     }
 
     /// Do nothing for this dummy pipeline.

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -55,6 +55,7 @@ export const KEYS = [
             { type: Type.B, name: "blur" },
             { type: Type.I, name: "sigma" },
             { type: Type.D, name: "brightness" },
+            { type: Type.I, name: "corner-radius" },
             { type: Type.I, name: "opacity" },
             { type: Type.B, name: "dynamic-opacity" },
             { type: Type.B, name: "blur-on-overview" },
@@ -155,6 +156,7 @@ export const DEPRECATED_KEYS = [
             { type: Type.C, name: "color" },
             { type: Type.D, name: "noise-amount" },
             { type: Type.D, name: "noise-lightness" },
+            { type: Type.I, name: "corner-radius" },
         ]
     },
     {

--- a/src/preferences/applications.js
+++ b/src/preferences/applications.js
@@ -32,6 +32,7 @@ export const Applications = GObject.registerClass({
         'blur',
         'sigma',
         'brightness',
+        'corner_radius',
         'opacity',
         'dynamic_opacity',
         'blur_on_overview',
@@ -74,6 +75,10 @@ export const Applications = GObject.registerClass({
         );
         this.preferences.applications.settings.bind(
             'brightness', this._brightness, 'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.preferences.applications.settings.bind(
+            'corner-radius', this._corner_radius, 'value',
             Gio.SettingsBindFlags.DEFAULT
         );
 


### PR DESCRIPTION
## Summary
- allow the applications blur to specify rounded corners
- keep radius in gschema and expose it in preferences
- update DummyPipeline to react to radius changes
- bind the new corner-radius UI element
- register the key and keep blur actor aligned on focus changes

## Testing
- `glib-compile-schemas schemas`


------
https://chatgpt.com/codex/tasks/task_e_687fbcc30a34832ab94b7ab976fcb65b